### PR TITLE
Making attribute "Text" of "Attachment" omitempty

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -75,7 +75,7 @@ type Attachment struct {
 	Title     string `json:"title,omitempty"`
 	TitleLink string `json:"title_link,omitempty"`
 	Pretext   string `json:"pretext,omitempty"`
-	Text      string `json:"text"` // Required
+	Text      string `json:"text,omitempty"`
 
 	ImageURL string `json:"image_url,omitempty"`
 	ThumbURL string `json:"thumb_url,omitempty"`


### PR DESCRIPTION
The field is no more required for unfurling a slack message on send mode "chat.unfurl". When sending a POST where the unfurl attachments contains together "text" and "blocks" goes into an "cannot_parse_attachment" error.